### PR TITLE
Feature/audit revision 1

### DIFF
--- a/BEP20Token.sol
+++ b/BEP20Token.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.6.6;
+
+import "./Context.sol";
+import "./IBEP20.sol";
+import "./Ownable.sol";
+import "./SafeMath.sol";
+
+contract BEP20Token is Context, IBEP20, Ownable {
+  using SafeMath for uint256;
+
+  mapping (address => uint256) private _balances;
+
+  mapping (address => mapping (address => uint256)) private _allowances;
+
+  uint256 private _totalSupply;
+  uint8 private _decimals;
+  string private _symbol;
+  string private _name;
+
+  constructor(string memory name, string memory symbol, uint8 decimals, uint256 totalSupply) public {
+    _name = name;
+    _symbol = symbol;
+    _decimals = decimals;
+    _totalSupply = totalSupply;
+    _balances[msg.sender] = _totalSupply;
+
+    emit Transfer(address(0), msg.sender, _totalSupply);
+  }
+  
+  /**
+   * @dev Returns the bep token owner.
+   */
+  function getOwner() external override view returns (address) {
+    return owner();
+  }
+
+  /**
+   * @dev Returns the token decimals.
+   */
+  function decimals() external override view returns (uint8) {
+    return _decimals;
+  }
+
+  /**
+   * @dev Returns the token symbol.
+   */
+  function symbol() external override view returns (string memory) {
+    return _symbol;
+  }
+
+  /**
+  * @dev Returns the token name.
+  */
+  function name() external override view returns (string memory) {
+    return _name;
+  }
+
+  /**
+   * @dev See {BEP20-totalSupply}.
+   */
+  function totalSupply() external override view returns (uint256) {
+    return _totalSupply;
+  }
+
+  /**
+   * @dev See {BEP20-balanceOf}.
+   */
+  function balanceOf(address account) external override view returns (uint256) {
+    return _balances[account];
+  }
+
+  /**
+   * @dev See {BEP20-transfer}.
+   *
+   * Requirements:
+   *
+   * - `recipient` cannot be the zero address.
+   * - the caller must have a balance of at least `amount`.
+   */
+  function transfer(address recipient, uint256 amount) external override returns (bool) {
+    _transfer(_msgSender(), recipient, amount);
+    return true;
+  }
+
+  /**
+   * @dev See {BEP20-allowance}.
+   */
+  function allowance(address owner, address spender) external override view returns (uint256) {
+    return _allowances[owner][spender];
+  }
+
+  /**
+   * @dev See {BEP20-approve}.
+   *
+   * Requirements:
+   *
+   * - `spender` cannot be the zero address.
+   */
+  function approve(address spender, uint256 amount) external override returns (bool) {
+    _approve(_msgSender(), spender, amount);
+    return true;
+  }
+
+  /**
+   * @dev See {BEP20-transferFrom}.
+   *
+   * Emits an {Approval} event indicating the updated allowance. This is not
+   * required by the EIP. See the note at the beginning of {BEP20};
+   *
+   * Requirements:
+   * - `sender` and `recipient` cannot be the zero address.
+   * - `sender` must have a balance of at least `amount`.
+   * - the caller must have allowance for `sender`'s tokens of at least
+   * `amount`.
+   */
+  function transferFrom(address sender, address recipient, uint256 amount) external override returns (bool) {
+    _transfer(sender, recipient, amount);
+    _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "BEP20: transfer amount exceeds allowance"));
+    return true;
+  }
+
+  /**
+   * @dev Atomically increases the allowance granted to `spender` by the caller.
+   *
+   * This is an alternative to {approve} that can be used as a mitigation for
+   * problems described in {BEP20-approve}.
+   *
+   * Emits an {Approval} event indicating the updated allowance.
+   *
+   * Requirements:
+   *
+   * - `spender` cannot be the zero address.
+   */
+  function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+    _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+    return true;
+  }
+
+  /**
+   * @dev Atomically decreases the allowance granted to `spender` by the caller.
+   *
+   * This is an alternative to {approve} that can be used as a mitigation for
+   * problems described in {BEP20-approve}.
+   *
+   * Emits an {Approval} event indicating the updated allowance.
+   *
+   * Requirements:
+   *
+   * - `spender` cannot be the zero address.
+   * - `spender` must have allowance for the caller of at least
+   * `subtractedValue`.
+   */
+  function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
+    _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "BEP20: decreased allowance below zero"));
+    return true;
+  }
+
+  /**
+   * @dev Moves tokens `amount` from `sender` to `recipient`.
+   *
+   * This is internal function is equivalent to {transfer}, and can be used to
+   * e.g. implement automatic token fees, slashing mechanisms, etc.
+   *
+   * Emits a {Transfer} event.
+   *
+   * Requirements:
+   *
+   * - `sender` cannot be the zero address.
+   * - `recipient` cannot be the zero address.
+   * - `sender` must have a balance of at least `amount`.
+   */
+  function _transfer(address sender, address recipient, uint256 amount) internal {
+    require(sender != address(0), "BEP20: transfer from the zero address");
+    require(recipient != address(0), "BEP20: transfer to the zero address");
+
+    _balances[sender] = _balances[sender].sub(amount, "BEP20: transfer amount exceeds balance");
+    _balances[recipient] = _balances[recipient].add(amount);
+    emit Transfer(sender, recipient, amount);
+  }
+
+  /**
+   * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+   *
+   * This is internal function is equivalent to `approve`, and can be used to
+   * e.g. set automatic allowances for certain subsystems, etc.
+   *
+   * Emits an {Approval} event.
+   *
+   * Requirements:
+   *
+   * - `owner` cannot be the zero address.
+   * - `spender` cannot be the zero address.
+   */
+  function _approve(address owner, address spender, uint256 amount) internal {
+    require(owner != address(0), "BEP20: approve from the zero address");
+    require(spender != address(0), "BEP20: approve to the zero address");
+
+    _allowances[owner][spender] = amount;
+    emit Approval(owner, spender, amount);
+  }
+
+  /**
+   * @dev Destroys `amount` tokens from msg.sender, reducing the
+   * total supply.
+   *
+   * Emits a {Transfer} event with `to` set to the zero address.
+   *
+   * Requirements
+   *
+   * - msg.sender must have at least `amount` tokens.
+   */
+  function burn(uint256 amount) external {
+    _burn(msg.sender, amount);
+  }
+
+  /**
+   * @dev Destroys `amount` tokens from `account`, reducing the
+   * total supply.
+   *
+   * Emits a {Transfer} event with `to` set to the zero address.
+   *
+   * Requirements
+   *
+   * - `account` cannot be the zero address.
+   * - `account` must have at least `amount` tokens.
+   */
+  function _burn(address account, uint256 amount) internal {
+    require(account != address(0), "BEP20: burn from the zero address");
+
+    _balances[account] = _balances[account].sub(amount, "BEP20: burn amount exceeds balance");
+    _totalSupply = _totalSupply.sub(amount);
+    emit Transfer(account, address(0), amount);
+  }
+
+}

--- a/stake/BytexBYCBNBPool.sol
+++ b/stake/BytexBYCBNBPool.sol
@@ -12,10 +12,9 @@ contract BytexBYCBNBPool is StakeWrapper {
     address _bytexToken, 
     address _stakingToken, 
     uint256 _rateLimiter, 
-    uint256 _unstakeFee,
     uint256[] memory levelLimit, 
     uint256[] memory levelRate
-  ) StakeWrapper(_bytexToken, _stakingToken, _rateLimiter, _unstakeFee, levelLimit, levelRate) public {
+  ) StakeWrapper(_bytexToken, _stakingToken, _rateLimiter, levelLimit, levelRate) public {
   }
 
 }

--- a/stake/BytexBYXBNBPool.sol
+++ b/stake/BytexBYXBNBPool.sol
@@ -12,10 +12,9 @@ contract BytexBYXBNBPool is StakeWrapper {
     address _bytexToken, 
     address _stakingToken, 
     uint256 _rateLimiter, 
-    uint256 _unstakeFee,
     uint256[] memory levelLimit, 
     uint256[] memory levelRate
-  ) StakeWrapper(_bytexToken, _stakingToken, _rateLimiter, _unstakeFee, levelLimit, levelRate) public {
+  ) StakeWrapper(_bytexToken, _stakingToken, _rateLimiter, levelLimit, levelRate) public {
   }
 
 }

--- a/stake/BytexWBNBPool.sol
+++ b/stake/BytexWBNBPool.sol
@@ -12,10 +12,9 @@ contract BytexWBNBPool is StakeWrapper {
     address _bytexToken, 
     address _stakingToken, 
     uint256 _rateLimiter, 
-    uint256 _unstakeFee,
     uint256[] memory levelLimit, 
     uint256[] memory levelRate
-  ) StakeWrapper(_bytexToken, _stakingToken, _rateLimiter, _unstakeFee, levelLimit, levelRate) public {
+  ) StakeWrapper(_bytexToken, _stakingToken, _rateLimiter, levelLimit, levelRate) public {
   }
 
 }

--- a/tokens/BytexCasinoToken.sol
+++ b/tokens/BytexCasinoToken.sol
@@ -4,6 +4,6 @@ pragma solidity ^0.6.6;
 import "../BEP20Token.sol";
 
 contract BytexCasinoToken is BEP20Token {
-  constructor() public BEP20Token("Bytex Casino Token", "BBC", 18, 100 * 1e6 * 1e18) {
+  constructor() public BEP20Token("Bytex Casino Token", "BYC", 18, 100 * 1e6 * 1e18) {
   }
 }


### PR DESCRIPTION
**Tokens Contracts**
1. Add base BEP20Token contract

**Staking Contract**
1. Change stake, claimReward, withdrawFees, user, stats function from 'public' to 'external'.
2. Add 'setWithdrawalFees' function to have unstake fee based on pool (with restriction of fee up to 5%).
3. Rename ambiguous function names [withdrawFees -> withdrawAllFees, unstake -> unstakeAll].

**Casino Contract** 
1. Change all  function from 'public' to 'external'.
2. Logic to track of total token still in play and update 'collectProfit' function logic to restrict collecting tokens that are still in play.
3. Use SafeMath while calculating BYC token mining rate.
4. Change logic to have only one signer (croupiers cannot sign, used only for multiple concurrent transactions).